### PR TITLE
Feedback-Persistenz, CSV-Export und Follow-up Bugfix > fehlendes Feedback-Menü bei Folgefragen

### DIFF
--- a/apps/chainlit/Dockerfile
+++ b/apps/chainlit/Dockerfile
@@ -6,10 +6,13 @@ ENV PIP_NO_CACHE_DIR=1
 
 WORKDIR /app
 
-COPY . /app
-
+# Dependencies first → cached unless pyproject.toml changes
+COPY pyproject.toml /app/
 RUN pip install --upgrade pip \
     && pip install -e .
+
+# App code + static assets last → fast rebuilds on CSS/JS changes
+COPY . /app
 
 EXPOSE 8000
 

--- a/apps/chainlit/app.py
+++ b/apps/chainlit/app.py
@@ -40,7 +40,9 @@ from native_chat import (
     create_user,
     ensure_native_schema,
     export_all_chats_zip,
+    export_feedback_csv,
     get_user_by_identifier,
+    upsert_feedback,
 )
 from rag_tool import build_context, extract_page, extract_source_file, format_citations, retrieve, personalized_retrieve
 from settings import (
@@ -2036,14 +2038,43 @@ async def on_app_startup() -> None:
 
         return {"message": "Registrierung erfolgreich", "username": user["identifier"]}
 
+    @chainlit_fastapi_app.get("/export/feedback")
+    async def export_feedback(current_user=Depends(get_current_user)):
+        if current_user is None:
+            raise HTTPException(status_code=401, detail="Unauthorized")
+        csv_file = await export_feedback_csv(
+            database_url=DATABASE_URL,
+            out_dir=CHAT_EXPORT_DIR,
+        )
+        return FileResponse(
+            path=str(csv_file),
+            media_type="text/csv; charset=utf-8",
+            filename=csv_file.name,
+        )
+
     _ensure_route_precedes_catch_all(chainlit_fastapi_app, "/sources/pdf/{file_name:path}")
     _ensure_route_precedes_catch_all(chainlit_fastapi_app, "/sources/citations/{step_id}")
     _ensure_route_precedes_catch_all(chainlit_fastapi_app, "/export/all-chats")
+    _ensure_route_precedes_catch_all(chainlit_fastapi_app, "/export/feedback")
     _ensure_route_precedes_catch_all(chainlit_fastapi_app, "/auth/register")
 
     chainlit_fastapi_app.state.native_export_route_added = True
     print("[STARTUP] native export route registered at /export/all-chats")
+    print("[STARTUP] feedback export route registered at /export/feedback")
     print("[STARTUP] registration route registered at /auth/register")
+
+
+@cl.on_feedback
+async def on_feedback(feedback: cl.types.Feedback):
+    if not DATABASE_URL:
+        return
+    await upsert_feedback(
+        DATABASE_URL,
+        feedback_id=feedback.id or str(__import__("uuid").uuid4()),
+        step_id=feedback.forId,
+        value=float(feedback.value),
+        comment=feedback.comment,
+    )
 
 
 @cl.on_chat_resume

--- a/apps/chainlit/app.py
+++ b/apps/chainlit/app.py
@@ -2042,6 +2042,9 @@ async def on_app_startup() -> None:
     async def export_feedback(current_user=Depends(get_current_user)):
         if current_user is None:
             raise HTTPException(status_code=401, detail="Unauthorized")
+        user_meta = getattr(current_user, "metadata", None) or {}
+        if user_meta.get("role") != "admin":
+            raise HTTPException(status_code=403, detail="Admin access required")
         csv_file = await export_feedback_csv(
             database_url=DATABASE_URL,
             out_dir=CHAT_EXPORT_DIR,

--- a/apps/chainlit/native_chat.py
+++ b/apps/chainlit/native_chat.py
@@ -203,6 +203,48 @@ async def check_user_exists(
         await conn.close()
 
 
+async def upsert_feedback(
+    database_url: str,
+    *,
+    feedback_id: str,
+    step_id: str,
+    value: float,
+    comment: str | None = None,
+) -> None:
+    """Insert or update a feedback row in the Feedback table.
+
+    Uses a unique constraint on ``stepId`` so that repeated clicks on the
+    same step always update the existing row instead of creating duplicates.
+    """
+    import uuid as _uuid
+
+    conn = await asyncpg.connect(database_url)
+    try:
+        # Ensure the unique index exists (idempotent).
+        await conn.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS "Feedback_stepId_unique"
+            ON "Feedback" ("stepId")
+            """
+        )
+        await conn.execute(
+            """
+            INSERT INTO "Feedback" (id, "stepId", name, value, comment)
+            VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT ("stepId") DO UPDATE
+              SET value   = EXCLUDED.value,
+                  comment = EXCLUDED.comment
+            """,
+            _uuid.UUID(feedback_id),
+            _uuid.UUID(step_id),
+            "user-feedback",
+            value,
+            comment,
+        )
+    finally:
+        await conn.close()
+
+
 async def export_all_chats_zip(
     *,
     database_url: str,
@@ -331,3 +373,85 @@ async def export_all_chats_zip(
         zf.write(jsonl_path, arcname=jsonl_path.name)
         zf.write(csv_path, arcname=csv_path.name)
     return zip_path
+
+
+async def export_feedback_csv(
+    *,
+    database_url: str,
+    out_dir: Path,
+) -> Path:
+    """Export all feedback rows joined with question, answer and user as CSV."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = out_dir / f"feedback-export-{_stamp()}.csv"
+
+    conn = await asyncpg.connect(database_url)
+    try:
+        rows = await conn.fetch(
+            """
+            SELECT
+              u.identifier                  AS username,
+              user_q.output                 AS user_question,
+              COALESCE(child.output, s.output) AS assistant_answer,
+              f.value                       AS feedback_value,
+              f.comment                     AS feedback_comment,
+              s."createdAt"                 AS answer_time,
+              t.id                          AS thread_id,
+              f.id                          AS feedback_id,
+              f."stepId"                    AS step_id
+            FROM "Feedback" f
+            JOIN "Step" s   ON s.id = f."stepId"
+            JOIN "Thread" t ON t.id = s."threadId"
+            LEFT JOIN "User" u ON u.id = t."userId"
+            LEFT JOIN LATERAL (
+                SELECT cs.output
+                FROM "Step" cs
+                WHERE cs."parentId" = s.id
+                  AND cs.type = 'assistant_message'
+                ORDER BY cs."startTime" DESC
+                LIMIT 1
+            ) child ON true
+            LEFT JOIN LATERAL (
+                SELECT qs.output
+                FROM "Step" qs
+                WHERE qs."threadId" = s."threadId"
+                  AND qs.type = 'user_message'
+                  AND qs."startTime" < s."startTime"
+                ORDER BY qs."startTime" DESC
+                LIMIT 1
+            ) user_q ON true
+            ORDER BY s."createdAt" DESC
+            """
+        )
+
+        fieldnames = [
+            "username",
+            "user_question",
+            "assistant_answer",
+            "feedback_value",
+            "feedback_comment",
+            "answer_time",
+            "thread_id",
+            "feedback_id",
+            "step_id",
+        ]
+        with csv_path.open("w", encoding="utf-8", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            for row in rows:
+                writer.writerow(
+                    {
+                        "username": row["username"] or "",
+                        "user_question": row["user_question"] or "",
+                        "assistant_answer": row["assistant_answer"] or "",
+                        "feedback_value": row["feedback_value"] if row["feedback_value"] is not None else "",
+                        "feedback_comment": row["feedback_comment"] or "",
+                        "answer_time": row["answer_time"].isoformat() if row["answer_time"] else "",
+                        "thread_id": str(row["thread_id"]) if row["thread_id"] else "",
+                        "feedback_id": str(row["feedback_id"]) if row["feedback_id"] else "",
+                        "step_id": str(row["step_id"]) if row["step_id"] else "",
+                    }
+                )
+    finally:
+        await conn.close()
+
+    return csv_path

--- a/apps/chainlit/public/custom.css
+++ b/apps/chainlit/public/custom.css
@@ -1,4 +1,14 @@
 /* Make action buttons roomier and allow long follow-up questions to remain readable. */
+[data-testid="message-actions"],
+[data-testid="actions"],
+.message-actions,
+[class*="message-actions"] {
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: 8px;
+  clear: both;
+}
+
 [data-testid="message-actions"] button,
 [data-testid="actions"] button,
 .message-actions button,

--- a/docs/feedback-export.md
+++ b/docs/feedback-export.md
@@ -1,0 +1,90 @@
+# Feedback-Persistierung & CSV-Export
+
+**Branch:** `feature/feedback-export`  
+**Commit:** `6ead407`  
+**Datum:** 2026-04-08  
+**Geänderte Dateien:** 2 Dateien, +155 Zeilen
+
+## Überblick
+
+Chainlit zeigt in der Chat-UI Feedback-Buttons (Helpful / Not helpful + optionaler Freitext-Kommentar).
+Ohne einen registrierten `@cl.on_feedback`-Handler werden diese Klicks jedoch **nicht** in der Datenbank gespeichert.
+
+Dieses Feature ergänzt:
+
+1. **Persistierung** – Feedback wird beim Klick in die PostgreSQL-`Feedback`-Tabelle geschrieben.
+2. **CSV-Export** – Ein authentifizierter HTTP-Endpoint liefert alle Feedback-Daten aller Nutzer als CSV-Download.
+
+## Geänderte Dateien
+
+### `apps/chainlit/native_chat.py` (+124 Zeilen)
+
+| Funktion | Beschreibung |
+|---|---|
+| `upsert_feedback()` | Speichert Feedback in die PostgreSQL-`Feedback`-Tabelle. Nutzt `ON CONFLICT ("stepId")` statt `ON CONFLICT (id)`, damit wiederholte Klicks auf denselben Step das bestehende Feedback aktualisieren statt Duplikate zu erzeugen. Erstellt idempotent einen Unique Index `Feedback_stepId_unique`. |
+| `export_feedback_csv()` | Exportiert alle Feedback-Daten als CSV. Löst per `LEFT JOIN LATERAL` die korrekte Assistenz-Antwort auf (Child-Step vom Typ `assistant_message`, da Feedback an `run`-Steps hängt, die selbst keinen Output haben). Ebenso wird die vorangehende User-Frage per LATERAL JOIN ermittelt. |
+
+### `apps/chainlit/app.py` (+31 Zeilen)
+
+| Änderung | Beschreibung |
+|---|---|
+| `@cl.on_feedback` Handler | Persistiert Feedback-Events (Helpful/Not helpful + Kommentar) über `upsert_feedback()` in PostgreSQL. Ohne diesen Handler zeigt Chainlit zwar die Buttons, speichert aber nichts. |
+| `GET /export/feedback` | Authentifizierter Endpoint, liefert CSV-Download aller Feedback-Daten aller Nutzer. |
+| Imports | `export_feedback_csv` und `upsert_feedback` aus `native_chat` importiert. |
+
+## DB-Schema-Änderung
+
+- **Unique Index** `Feedback_stepId_unique` auf `"Feedback"."stepId"` – verhindert doppelte Feedback-Einträge pro Step.
+- Der Index wird beim ersten Aufruf von `upsert_feedback()` idempotent via `CREATE UNIQUE INDEX IF NOT EXISTS` angelegt.
+
+## Datenmodell-Hintergrund
+
+Chainlit hängt Feedback an **`run`-Steps** (den `on_message`-Wrapper), nicht an `assistant_message`-Steps.
+`run`-Steps haben jedoch keinen eigenen Output – die eigentliche Antwort steckt in einem **Child-Step** vom Typ `assistant_message` mit `parentId = run.id`.
+
+Die Export-Query löst dies via:
+```sql
+LEFT JOIN LATERAL (
+    SELECT cs.output FROM "Step" cs
+    WHERE cs."parentId" = s.id AND cs.type = 'assistant_message'
+    ORDER BY cs."startTime" DESC LIMIT 1
+) child ON true
+```
+und verwendet `COALESCE(child.output, s.output)` als Fallback.
+
+## CSV-Spalten
+
+| Spalte | Beschreibung |
+|---|---|
+| `username` | Benutzername (aus `User.identifier` via Thread) |
+| `user_question` | Die Nutzerfrage (vorhergehender `user_message`-Step) |
+| `assistant_answer` | Die Assistenz-Antwort (Child `assistant_message`-Step) |
+| `feedback_value` | `1.0` = Helpful, `0.0` = Not helpful |
+| `feedback_comment` | Optionaler Freitext-Kommentar |
+| `answer_time` | Zeitstempel der Antwort (ISO 8601) |
+| `thread_id` | UUID des Chat-Threads |
+| `feedback_id` | UUID des Feedback-Eintrags |
+| `step_id` | UUID des Steps, an den das Feedback gehängt wurde |
+
+## Nutzung
+
+### CSV-Export über Browser
+
+```
+http://localhost:8000/export/feedback
+```
+
+Erfordert Authentifizierung (Login-Cookie oder OAuth-Token). Liefert alle Feedback-Daten aller Nutzer.
+
+### Ad-hoc-Abfrage über PostgreSQL
+
+```bash
+sudo docker exec gski-postgres psql -U chainlit -d chainlit -c '
+SELECT u.identifier, f.value, f.comment, s."createdAt"
+FROM "Feedback" f
+JOIN "Step" s ON s.id = f."stepId"
+JOIN "Thread" t ON t.id = s."threadId"
+LEFT JOIN "User" u ON u.id = t."userId"
+ORDER BY s."createdAt" DESC;
+'
+```


### PR DESCRIPTION
Hier ist die PR-Beschreibung:

---

**Issue**: (kein Issue-Ticket vorhanden)

**Description**:

**Type: Feature + Bugfix**

This PR adds feedback persistence and a CSV export endpoint, plus fixes a UI bug with follow-up questions.

**Changes:**

1. **Feedback persistence** (app.py, `native_chat.py`):
   - Add `@cl.on_feedback` handler to persist thumbs up/down + optional comment to PostgreSQL `Feedback` table
   - `upsert_feedback()` uses `ON CONFLICT("stepId")` to prevent duplicate rows per step
   - Unique index `Feedback_stepId_unique` created idempotently

2. **CSV export endpoint** (app.py, `native_chat.py`):
   - `GET /export/feedback` — admin-only endpoint (checks `role: "admin"` in user metadata, returns 403 otherwise)
   - `export_feedback_csv()` resolves full context via LATERAL JOINs: user question (preceding `user_message` Step), assistant answer (child `assistant_message` Step), username (Thread → User)
   - CSV columns: `username`, `user_question`, `assistant_answer`, `feedback_value`, `feedback_comment`, `answer_time`, `thread_id`, `feedback_id`, `step_id`

3. **Follow-up button fix** (app.py, custom.css):
   - `ask_followup` callback now wraps `main()` in a `cl.Step(type="run")` — matching what `@cl.on_message` does internally — so Chainlit renders copy/thumbs-up/thumbs-down buttons on follow-up responses
   - CSS: added `margin-top` to action button containers for visual separation from the feedback bar

4. **Dockerfile optimization** (Dockerfile):
   - Copy pyproject.toml and install dependencies first, then copy app code — so Docker layer cache is preserved on code-only changes

**Take care of:**
- The Chainlit Step hierarchy is: `run` (on_message wrapper, no output) → child `assistant_message` (actual answer). Feedback attaches to the `run` Step, not the `assistant_message`.
- The admin check relies on `metadata.role == "admin"`, which is set automatically for the env-based login (`CHAINLIT_AUTH_USERNAME`). DB-registered users do not have admin role by default.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Personalization system: Set custom prompts and manage keywords for tailored chat experiences.
  * Feedback export: Collect and export chat feedback via admin endpoint for analysis.
  * Enhanced settings UI: Profile selector, personalization toggle, keyword tags, and editable system prompt.

* **Updates**
  * Refined chat profiles with improved context and guidance.

* **Improvements**
  * Better action button layout and auto-resizing text input areas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aihpi/pilotprojekt-GrundschutzKI/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->